### PR TITLE
Add execute permissions to hadolint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM redcoolbeans/dockerlint:latest
 COPY LICENSE README.md hadolint /
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM redcoolbeans/dockerlint:latest
 COPY LICENSE README.md hadolint /
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /hadolint
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Add the run permission to hadolint in Dockerfile to correct the error:

`/entrypoint.sh: line 6: /hadolint: Permission denied`